### PR TITLE
Added code for Swagger + Redoc documentation

### DIFF
--- a/django/.env.dev
+++ b/django/.env.dev
@@ -5,3 +5,5 @@ DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
 POSTGRES_NAME=feupexchange
 POSTGRES_USER=admin
 POSTGRES_PASSWORD=admin123
+
+SWAGGER_BASE_URL=http://localhost:8000

--- a/django/.env.prod
+++ b/django/.env.prod
@@ -5,3 +5,5 @@ DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
 POSTGRES_NAME=feupexchange
 POSTGRES_USER=admin
 POSTGRES_PASSWORD=admin123
+
+SWAGGER_BASE_URL=http://localhost:8000

--- a/django/feup_exchange_backend/schemas.py
+++ b/django/feup_exchange_backend/schemas.py
@@ -9,7 +9,7 @@ TestServiceSuccessResponse = \
             properties={
                 "message": openapi.Response(
                     type=openapi.TYPE_STRING,
-                    enum=["Yep, it\'s working!"],
+                    enum=["Yep, it's working!"],
                     description="Message indicating that the service is "
                                 "available and functioning properly."
                 ),

--- a/django/feup_exchange_backend/schemas.py
+++ b/django/feup_exchange_backend/schemas.py
@@ -1,0 +1,18 @@
+from drf_yasg import openapi
+
+TestServiceSuccessResponse = \
+    openapi.Response(
+        description="OK",
+        schema=openapi.Schema(
+            title="Test Service",
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "message": openapi.Response(
+                    type=openapi.TYPE_STRING,
+                    enum=["Yep, it\'s working!"],
+                    description="Message indicating that the service is "
+                                "available and functioning properly."
+                ),
+            },
+        )
+    )

--- a/django/feup_exchange_backend/settings.py
+++ b/django/feup_exchange_backend/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [
@@ -125,6 +126,21 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 MEDIA_URL = "/mediafiles/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "mediafiles")
+
+SWAGGER_SETTINGS = {
+    "DOC_EXPANSION": "none",
+    "HIDE_HOSTNAME": True,
+    "DEFAULT_FILTER_INSPECTORS": ['drf_yasg.inspectors.CoreAPICompatInspector'],
+    "FILTER": False,
+    "SHOW_EXTENSIONS": False,
+    "SECURITY_DEFINITIONS": {
+        'Token': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header'
+        }
+    }
+}
 
 # -- Renderers
 REST_FRAMEWORK = {

--- a/django/feup_exchange_backend/urls.py
+++ b/django/feup_exchange_backend/urls.py
@@ -1,14 +1,39 @@
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.conf import settings
 from django.conf.urls.static import static
+from rest_framework import permissions
+
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+import os
 
 from .views import TestServiceView
 
+# # -- Load Swagger
+schema_view = get_schema_view(
+    openapi.Info(
+        title="FEUP Exchange REST API",
+        default_version='v1',
+        description="Swagger web platform that can be used to access the "
+                    "FEUP Exchange REST API endpoints."
+    ),
+    public=False,
+    permission_classes=(permissions.AllowAny,),
+    url=os.environ.get("SWAGGER_BASE_URL", default=None)
+)
+
 urlpatterns = [
+    re_path(r'^swagger(?P<format>\.json|\.yaml)$',
+            schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    re_path(r'^swagger/?$', schema_view.with_ui('swagger',
+                                                cache_timeout=0), name='schema-swagger-ui'),
+    re_path(r'^redoc/?$', schema_view.with_ui('redoc',
+                                              cache_timeout=0), name='schema-redoc'),
+
     path('admin/', admin.site.urls),
     path('api-auth/', include('rest_framework.urls')),
-    path('', TestServiceView.as_view(), name="test")
+    re_path(r'^test/?$', TestServiceView.as_view(), name="test")
 ]
 
 if bool(settings.DEBUG):

--- a/django/feup_exchange_backend/views.py
+++ b/django/feup_exchange_backend/views.py
@@ -1,7 +1,8 @@
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
+from drf_yasg.utils import swagger_auto_schema
+from .schemas import TestServiceSuccessResponse
 
 class TestServiceView(APIView):
     """
@@ -10,6 +11,13 @@ class TestServiceView(APIView):
     permission_classes = []
     authentication_classes = []
 
+    @swagger_auto_schema(
+        operation_id="Test Service",
+        operation_description="Endpoint to test the availability of the FEUP Exchange service.",
+        responses={
+            200: TestServiceSuccessResponse,
+        }
+    )
     def get(self, request):
         """
         GET method of the test service view.

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -8,3 +8,4 @@ autopep8==1.5
 gunicorn==19.9.0
 packaging==19.0
 django-cors-headers==3.5.0
+drf-yasg==1.20.0


### PR DESCRIPTION
Added the [drf-yasg](https://pypi.org/project/drf-yasg/) package, which allows the use of decorators like `@swagger_auto_schema` to provide documentation for a particular endpoint, for the request parameters and the response bodies.

Two new endpoints were introduced:

* `/swagger` - Access to the Swagger interface, that can be used to make requests to documented endpoints;
* `/redoc` - Access to the Redoc documentation page.

Closes #14.