### PR TITLE
Added endpoint response for the algorithm execution deadline

### DIFF
--- a/django/algorithm/serializers.py
+++ b/django/algorithm/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+
+from .models import Deadline
+
+class DeadlineSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Deadline
+        fields = ['time']

--- a/django/algorithm/urls.py
+++ b/django/algorithm/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import DeadlineView
+
+urlpatterns = [
+    path('deadline/', DeadlineView.as_view(), name="deadline"),
+]

--- a/django/algorithm/views.py
+++ b/django/algorithm/views.py
@@ -1,3 +1,19 @@
-from django.shortcuts import render
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.views import status
 
-# Create your views here.
+from .serializers import DeadlineSerializer
+
+class DeadlineView(APIView):
+    """
+    View that fetches the datetime for when the algorithm is scheduled to execute
+    """
+    def get(self, request):
+        """
+        GET method of the dealine fetching view
+        """
+        serializer = DeadlineSerializer(data=request.data)
+        if serializer.is_valid():
+            return Response(data=serializer.data, status=status.HTTP_200_OK)
+        
+        return Response(data=serializer.errors)

--- a/django/feup_exchange_backend/urls.py
+++ b/django/feup_exchange_backend/urls.py
@@ -8,6 +8,7 @@ from .views import TestServiceView
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api-auth/', include('rest_framework.urls')),
+    path('algorithm/', include('algorithm.urls')),
     path('user/', include('user.urls')),
     path('', TestServiceView.as_view(), name="test")
 ]


### PR DESCRIPTION
Closes #27 

Created new endoint:
`GET /algorithm/deadline` : returns the datetime database field for when the algorithm is scheduled to execute.